### PR TITLE
Clean up SetKernelBrk and occupy_pages_up_to

### DIFF
--- a/yalnix.c
+++ b/yalnix.c
@@ -10,7 +10,7 @@ void occupy_pages_up_to(void *end);
 //int array that keeps track of what pages are free (0 means free, 1 means not free)
 int *is_page_free;
 int virt_mem_initialized = 0;
-void *kernel_brk = PMEM_BASE;
+void *kernel_brk = VMEM_1_BASE;
 void **interrupt_vector_table;
 
 int SetKernelBrk(void *addr) {


### PR DESCRIPTION
If you look at the picture on page 22, you can see that nothing is used at the bottom near PMEM_BASE. We should initially be setting kernel_brk to VMEM_1_BASE, and then allocating up to orig_brk, and beyond.
